### PR TITLE
グループ作成時のview画面実装

### DIFF
--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -1,0 +1,117 @@
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+
+  h1 {
+    letter-spacing: 2px;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+  }
+
+  .chat-group-form__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+
+    h2 {
+      margin-bottom: 10px;
+      color: #f05050;
+      font-size: 14px;
+    }
+
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    li {
+      margin: 0;
+      padding: 0;
+      font-size: 13px;
+    }
+  }
+
+  .chat-group-form__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+
+    .chat-group-form__field--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+
+    .chat-group-form__field--right {
+      float: right;
+      width: 70%;
+    }
+
+    .chat-group-form__label {
+      display: block;
+      line-height: 50px;
+      font-weight: bold;
+      text-align: right;
+    }
+
+    .chat-group-form__input {
+      float: left;
+      width: 100%;
+      line-height: 30px;
+      padding: 10px 15px;
+      box-sizing: border-box;
+    }
+  }
+
+  .chat-group-user {
+    padding: 0 15px;
+    line-height: 50px;
+    font-size: 14px;
+    border-bottom: 1px solid #ddd;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+
+    .chat-group-user__name {
+      float: left;
+    }
+
+    .chat-group-user__btn {
+      float: right;
+      display: inline-block;
+      cursor: pointer;
+
+      &.chat-group-user__btn--add {
+        color: #38aef0;
+      }
+
+      &.chat-group-user__btn--remove {
+        color: #f05050;
+      }
+    }
+  }
+
+  .chat-group-form__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+}

--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -14,7 +14,7 @@
     text-align: center;
   }
 
-  .chat-group-form__errors {
+  &__errors {
     margin: 30px 0;
     padding: 20px 40px;
     border: 1px solid #ddd;
@@ -40,7 +40,7 @@
     }
   }
 
-  .chat-group-form__field {
+  &__field {
     margin-top: 30px;
     &:after {
       content: "";
@@ -48,7 +48,7 @@
       display: block;
     }
 
-    .chat-group-form__field--left {
+    &--left {
       float: left;
       width: 30%;
       padding-right: 20px;
@@ -56,7 +56,7 @@
       box-sizing: border-box;
     }
 
-    .chat-group-form__field--right {
+    &--right {
       float: right;
       width: 70%;
     }
@@ -88,26 +88,26 @@
       display: block;
     }
 
-    .chat-group-user__name {
+    &__name {
       float: left;
     }
 
-    .chat-group-user__btn {
+    &__btn {
       float: right;
       display: inline-block;
       cursor: pointer;
 
-      &.chat-group-user__btn--add {
+      &--add {
         color: #38aef0;
       }
 
-      &.chat-group-user__btn--remove {
+      &--remove {
         color: #f05050;
       }
     }
   }
 
-  .chat-group-form__action-btn {
+  &__action-btn {
     display: inline-block;
     padding: 12px 20px;
     color: #fff;

--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -60,21 +60,6 @@
       float: right;
       width: 70%;
     }
-
-    // .chat-group-form__label {
-    //   display: block;
-    //   line-height: 50px;
-    //   font-weight: bold;
-    //   text-align: right;
-    // }
-
-    // .chat-group-form__input {
-    //   float: left;
-    //   width: 100%;
-    //   line-height: 30px;
-    //   padding: 10px 15px;
-    //   box-sizing: border-box;
-    // }
   }
 
   .chat-group-user {

--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -61,20 +61,20 @@
       width: 70%;
     }
 
-    .chat-group-form__label {
-      display: block;
-      line-height: 50px;
-      font-weight: bold;
-      text-align: right;
-    }
+    // .chat-group-form__label {
+    //   display: block;
+    //   line-height: 50px;
+    //   font-weight: bold;
+    //   text-align: right;
+    // }
 
-    .chat-group-form__input {
-      float: left;
-      width: 100%;
-      line-height: 30px;
-      padding: 10px 15px;
-      box-sizing: border-box;
-    }
+    // .chat-group-form__input {
+    //   float: left;
+    //   width: 100%;
+    //   line-height: 30px;
+    //   padding: 10px 15px;
+    //   box-sizing: border-box;
+    // }
   }
 
   .chat-group-user {
@@ -113,5 +113,19 @@
     color: #fff;
     background-color: #38aef0;
     border: 0;
+  }
+
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import "./user";
 @import "config/colors";
 @import "modules/flash";
+@import "./group";

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,31 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  %form#edit_chat_group_22.edit_chat_group{"accept-charset": "UTF-8", action: "/chat_groups/22", method: "post"}
+    %input{name: "utf8", type: "hidden", value: "✓"}/
+    %input{name: "_method", type: "hidden", value: "patch"}/
+    %input{name: "authenticity_token", type: "hidden", value: "U5ABp0/UobRQTSwsR0V40bX1w3t0rZ0CTqrVyLecD+L6sdhBRO/gVcKy7w/Rgxnc7Hf0Ts39996dal3to5fTag=="}/
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
+    .chat-group-form__field.clearfix
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      /
+        <div class='chat-group-form__field--left'>
+        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+        </div>
+        <div class='chat-group-form__field--right'>
+        <div class='chat-group-form__search clearfix'>
+        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+        </div>
+        <div id='user-search-result'></div>
+        </div>
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,39 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "/chat_groups", method: "post"}
+    %input{name: "utf8", type: "hidden", value: "✓"}/
+    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}/
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+    .chat-group-form__field.clearfix
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      /
+        <div class='chat-group-form__field--left'>
+        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+        </div>
+        <div class='chat-group-form__field--right'>
+        <div class='chat-group-form__search clearfix'>
+        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+        </div>
+        <div id='user-search-result'></div>
+        </div>
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+        /
+          <div id='chat-group-users'>
+          <div class='chat-group-user clearfix' id='chat-group-user-22'>
+          <input name='chat_group[user_ids][]' type='hidden' value='22'>
+          <p class='chat-group-user__name'>seo_kyohei</p>
+          </div>
+          </div>
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -5,7 +5,7 @@
         %p 
           = current_user.name
         .sidebar_header_center-icon
-          = link_to(content_tag(:i, '', class: 'fa fa-edit'), "", method: :get) 
+          = link_to(content_tag(:i, '', class: 'fa fa-edit'), new_group_path, method: :get) 
           = link_to(content_tag(:i, '', class: 'fa fa-cog'), "", method: :get) 
     .sidebar_main
       .sidebar_main_center


### PR DESCRIPTION
#WHAT
・グループ作成時に表示されるビュー画面の素材をダウンロードしviewのgroupディレクトリに追加しました。対応するcssも追加しました。
・拡張子がerbでしたのでhamlに統一し、修正しました。
#WHY
・groupコントローラーのeditアクションとnewアクションに対応するviewファイルがなくルーティングしても作成画面が表示されなかったため。