### PR TITLE
メッセージ画面の非同期化

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,54 @@
+$(function(){
+  $form = $($.rails.formSubmitSelector)
+  function buildHTML(message){
+    var img = ""
+    if (message.image !== null) {
+        img = `<img src="${message.image}">`
+    }
+    var html = `
+                <div class="chat_main_center-message">
+                  <div class="chat_main_center-message-top">
+                    <div class="chat_main_center-message-top-user"> 
+                      ${message.user_name}
+                    </div>
+                    <div class="chat_main_center-message-top-date"> 
+                      ${message.created_at}
+                    </div>
+                  </div>
+                  <div class="chat_main_center-message-detail"> 
+                    <p class="lower-message__content">
+                      ${ message.content }
+                      ${ img }
+                    </p>
+                  </div>
+                </div>
+                    `
+    return html;
+  }
+  $("#new_message").on("submit",function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat_main_center').append(html)
+      $('.form__message').val('')
+      $('.chat_main_center').animate({
+        scrollTop: 1000
+    }, 1050);
+      $.rails.enableFormElements($form)
+    })
+    
+    .fail(function(){
+      alert('error');
+    })
+  })
+});

--- a/app/assets/stylesheets/_chat.scss
+++ b/app/assets/stylesheets/_chat.scss
@@ -72,6 +72,7 @@
     box-sizing: border-box;
     height: 90px;
     padding: 20px 50px 20px 40px;
+    z-index:10;
     &__message {
       border: none;
       float: left;

--- a/app/assets/stylesheets/messages/chat.scss
+++ b/app/assets/stylesheets/messages/chat.scss
@@ -49,11 +49,17 @@
   &_main{
     height:calc(100% - 190px);
     background-color: #fafafa;
+    
 
     &_center{
       height:calc(100% - 46px);
-      padding:0 40px;
-      padding-top:46px;
+      width:100%;
+      margin:0;
+      overflow:scroll;
+      padding:10px 40px;
+      padding-top:0;
+      
+      
 
       &-message{
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'  }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content  @message.content
+json.image  @message.image.url
+json.created_at  @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name @message.user.name


### PR DESCRIPTION
#WHAT
・グループ内でのメッセージ送信、送信後のメッセージ一覧画面表示を非同期化にする
#WHY
・サーバーからの待ち時間をなくしメッセージ送信後もすぐに別の動作ができるようにする為